### PR TITLE
Export wallet

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { networks } from 'liquidjs-lib';
 export * from './swap';
 export * from './trade';
 export * from './grpcClient';

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -112,6 +112,7 @@ export class Wallet extends WatchOnlyWallet implements WalletInterface {
   publicKey: string;
 
   static fromWIF = fromWIF;
+  static fromRandom = fromRandom;
 
   constructor({
     network,
@@ -167,6 +168,20 @@ function fromAddress(
     });
   } catch (ignore) {
     throw new Error('fromAddress: Invalid address or network');
+  }
+}
+
+function fromRandom(network?: string): WalletInterface {
+  const _network = network ? (networks as any)[network] : networks.liquid;
+  try {
+    const keyPair = ECPair.makeRandom({ network: _network });
+    const { address } = payments.p2wpkh({
+      pubkey: keyPair.publicKey,
+      network: _network,
+    });
+    return new Wallet({ keyPair, network: _network, address: address! });
+  } catch (ignore) {
+    throw new Error('fromRandom: Failed to create wallet');
   }
 }
 


### PR DESCRIPTION
* Add `wallet` to the exported modules.
This is useful, for example, for the `tdex-cli` so we can avoid having a copy of the `WalletInterface`.
Possibly also the `tdex-daemon` would use this implementation rather than the one (another copy) actually in place.
* Add a static `fromRandom` method to the `Wallet` class in order to be able to create new wallets
* Export liquidjs' `networks`

Please @tiero, review this.