### PR TITLE
Add google-protobuf to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "module": "dist/tdex-sdk.esm.js",
   "devDependencies": {
     "@types/jest": "^25.2.1",
+    "@types/google-protobuf": "^3.7.2",
     "husky": "^4.2.3",
     "ts-protoc-gen": "^0.12.0",
     "tsdx": "^0.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,6 +1064,11 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
+"@types/google-protobuf@^3.7.2":
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@types/google-protobuf/-/google-protobuf-3.7.2.tgz#cd8a360c193ce4d672575a20a79f49ba036d38d2"
+  integrity sha512-ifFemzjNchFBCtHS6bZNhSZCBu7tbtOe0e8qY0z2J4HtFXmPJjm6fXSaQsTG7yhShBEZtt2oP/bkwu5k+emlkQ==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"


### PR DESCRIPTION
This adds `google-protobuf` to dependencies in order to let this package to be imported standalone. At the moment, when importing it in a new projects, the user is forced to also import `google-protobuf` (for example tdex-cli).

This closes #11.

@tiero 