### PR TITLE
Move @types/google-protobuf to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "module": "dist/tdex-sdk.esm.js",
   "devDependencies": {
     "@types/jest": "^25.2.1",
-    "@types/google-protobuf": "^3.7.2",
     "husky": "^4.2.3",
     "ts-protoc-gen": "^0.12.0",
     "tsdx": "^0.13.1",
@@ -56,6 +55,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@types/google-protobuf": "^3.7.2",
     "axios": "^0.19.2",
     "google-protobuf": "^3.11.4",
     "grpc": "^1.24.2",


### PR DESCRIPTION
Having it into dev dependencies causes error `Missing @types/google-protobuf in node_modules`.

@tiero