### PR TITLE
add test for swapRequest & swapAccept transaction creation with Wallet

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,6 @@
 import JSBI from 'jsbi';
-import { confidential, Psbt, Transaction } from 'liquidjs-lib';
+import { confidential, Psbt, Transaction, TxOutput } from 'liquidjs-lib';
 import { UnblindOutputResult } from 'liquidjs-lib/types/confidential';
-import { Output } from 'liquidjs-lib/types/transaction';
 
 const HUNDRED = JSBI.BigInt(100);
 const TENTHOUSAND = JSBI.multiply(HUNDRED, HUNDRED);
@@ -122,7 +121,10 @@ export interface UnblindResult {
  * @param output the output to unblind.
  * @param blindKey the private blinding key.
  */
-export function unblindOutput(output: Output, blindKey: Buffer): UnblindResult {
+export function unblindOutput(
+  output: TxOutput,
+  blindKey: Buffer
+): UnblindResult {
   const result: UnblindResult = { asset: Buffer.alloc(0), value: 0 };
 
   if (!output.rangeProof) {
@@ -157,7 +159,7 @@ function bufferNotEmptyOrNull(buffer?: Buffer): boolean {
  * Checks if a given output is a confidential one.
  * @param output the ouput to check.
  */
-export function isConfidentialOutput(output: Output): boolean {
+export function isConfidentialOutput(output: TxOutput): boolean {
   return (
     bufferNotEmptyOrNull(output.rangeProof) &&
     bufferNotEmptyOrNull(output.surjectionProof) &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -114,7 +114,7 @@ export function isValidAmount(amount: number): boolean {
 export interface UnblindResult {
   asset: Buffer;
   // in satoshis
-  value: Number;
+  value: number;
 }
 
 /**

--- a/test/_regtest.ts
+++ b/test/_regtest.ts
@@ -39,3 +39,17 @@ export async function fetchTxHex(txId: string): Promise<string> {
   }
   return hex;
 }
+
+export async function mint(address: string, quantity: number): Promise<string> {
+  let ret: string;
+  try {
+    const response = await axios.post(`${APIURL}/mint`, { address, quantity });
+    await sleep(3000);
+    const { asset } = response.data;
+    ret = asset;
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+  return ret;
+}

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1,0 +1,129 @@
+import { AddressInterface } from './../src/types';
+import { UtxoInterface, Wallet, walletFromAddresses } from './../src/wallet';
+import {
+  ECPair,
+  networks,
+  payments,
+  TxOutput,
+  Transaction,
+} from 'liquidjs-lib';
+import { faucet, fetchUtxos, fetchTxHex, mint } from './_regtest';
+import * as assert from 'assert';
+import { Swap } from '../src/swap';
+import { toAssetHash, unblindOutput } from '../src/utils';
+
+const network = networks.regtest;
+
+const proposerKeypair = ECPair.fromWIF(
+  'cPNMJD4VyFnQjGbGs3kcydRzAbDCXrLAbvH6wTCqs88qg1SkZT3J',
+  network
+);
+
+const proposerBlindKeypair = ECPair.fromWIF(
+  'cRdrvnPMLV7CsEak2pGrgG4MY7S3XN1vjtcgfemCrF7KJRPeGgW6',
+  network
+);
+
+const responderKeypair = ECPair.fromWIF(
+  'cSv4PQtTpvYKHjfp9qih2RMeieBQAVADqc8JGXPvA7mkJ8yD5QC1',
+  network
+);
+
+const responderBlindKeypair = ECPair.fromWIF(
+  'cVcDj9Td96x8jcG1eudxKL6hdwziCTgvPhqBoazkDeFGSAR8pCG8',
+  network
+);
+
+const proposer = payments.p2wpkh({
+  pubkey: proposerKeypair.publicKey,
+  blindkey: proposerBlindKeypair.publicKey,
+  network,
+});
+
+const responder = payments.p2wpkh({
+  pubkey: responderKeypair.publicKey,
+  blindkey: responderBlindKeypair.publicKey,
+  network,
+});
+
+const proposerAddressInterface: AddressInterface = {
+  confidentialAddress: proposer.confidentialAddress!,
+  blindingPrivateKey: proposerBlindKeypair.privateKey!.toString('hex'),
+};
+
+jest.setTimeout(15000);
+
+describe('Wallet - Transaction builder', () => {
+  describe('SwapRequest transaction', () => {
+    let proposerUtxos: UtxoInterface[];
+    let shitcoin: string;
+
+    it('should let the Proposer to create a valid SwapRequest transaction', async () => {
+      // found the proposer account with LBTC
+      await faucet(proposer.confidentialAddress!);
+      proposerUtxos = await fetchUtxos(proposer.confidentialAddress!);
+      // mint for the responder
+      shitcoin = await mint(responder.confidentialAddress!, 100);
+
+      const txHexs: string[] = await Promise.all(
+        proposerUtxos.map(utxo => fetchTxHex(utxo.txid))
+      );
+
+      const outputs: TxOutput[] = txHexs.map(
+        (hex, index) => Transaction.fromHex(hex).outs[proposerUtxos[index].vout]
+      );
+
+      const unblindedUtxos: UtxoInterface[] = proposerUtxos.map(
+        (utxo: UtxoInterface, index: number) => {
+          const prevout = outputs[index];
+          const { asset, value } = unblindOutput(
+            prevout,
+            proposerBlindKeypair.privateKey!
+          );
+          return {
+            ...utxo,
+            asset: toAssetHash(asset),
+            value,
+            prevout,
+          };
+        }
+      );
+
+      // create the request tx using wallet
+      const proposerWallet: Wallet = walletFromAddresses(
+        [proposerAddressInterface],
+        'regtest'
+      );
+
+      const emptyPsbt = proposerWallet.createTx();
+
+      const {
+        psetBase64,
+        inputBlindingKeys,
+        outputBlindingKeys,
+      } = proposerWallet.updateTx(
+        emptyPsbt,
+        unblindedUtxos,
+        1_0000_0000,
+        100_0000_0000,
+        network.assetHash,
+        shitcoin,
+        proposerAddressInterface,
+        proposerAddressInterface
+      );
+
+      const swap = new Swap();
+      assert.doesNotThrow(() =>
+        swap.request({
+          amountToBeSent: 1_0000_0000,
+          assetToBeSent: network.assetHash,
+          amountToReceive: 100_0000_0000,
+          assetToReceive: shitcoin,
+          psbtBase64: psetBase64,
+          inputBlindingKeys,
+          outputBlindingKeys,
+        })
+      );
+    });
+  });
+});

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1,7 +1,7 @@
 import { UtxoInterface, Wallet, walletFromAddresses } from './../src/wallet';
-import { networks, TxOutput, Transaction } from 'liquidjs-lib';
+import { networks, TxOutput, Transaction, Psbt } from 'liquidjs-lib';
 import { faucet, fetchUtxos, fetchTxHex, mint } from './_regtest';
-// import * as assert from 'assert';
+import * as assert from 'assert';
 import { Swap } from '../src/swap';
 import PrivateKey from '../src/identities/privatekey';
 import { IdentityType } from '../src/identity';
@@ -33,9 +33,14 @@ const responderAddress = responder.getNextAddress().confidentialAddress;
 jest.setTimeout(15000);
 
 describe('Wallet - Transaction builder', () => {
+  let messageSwapRequest: Uint8Array;
+  let txSwapRequest: Psbt;
+  let shitcoin: string;
+  let inputsKeys: Record<string, Buffer>;
+  let outputsKeys: Record<string, Buffer>;
+
   describe('SwapRequest transaction', () => {
     let proposerUtxos: UtxoInterface[];
-    let shitcoin: string;
 
     it('should let the Proposer to create a valid transaction to be used in a SwapRequest message', async () => {
       // found the proposer account with LBTC
@@ -79,18 +84,78 @@ describe('Wallet - Transaction builder', () => {
         proposer.getNextAddress()
       );
 
+      inputsKeys = { ...inputBlindingKeys };
+      outputsKeys = { ...outputBlindingKeys };
+
+      assert.doesNotThrow(() => (txSwapRequest = Psbt.fromBase64(psetBase64)));
+
       const swap = new Swap();
-      // assert.doesNotThrow(() =>
-      swap.request({
-        amountToBeSent: 1_0000_0000,
-        assetToBeSent: network.assetHash,
-        amountToReceive: 100_0000_0000,
-        assetToReceive: shitcoin,
-        psbtBase64: psetBase64,
+      assert.doesNotThrow(() => {
+        messageSwapRequest = swap.request({
+          amountToBeSent: 1_0000_0000,
+          assetToBeSent: network.assetHash,
+          amountToReceive: 100_0000_0000,
+          assetToReceive: shitcoin,
+          psbtBase64: psetBase64,
+          inputBlindingKeys,
+          outputBlindingKeys,
+        });
+      });
+    });
+  });
+
+  describe('SwapAccept message', () => {
+    it('should let the proposer to create a valid transaction to be used for a Swap Accept', async () => {
+      const responderUtxos = await fetchUtxos(responderAddress);
+
+      const txHexs: string[] = await Promise.all(
+        responderUtxos.map((utxo: any) => fetchTxHex(utxo.txid))
+      );
+
+      const outputs: TxOutput[] = txHexs.map(
+        (hex, index) =>
+          Transaction.fromHex(hex).outs[responderUtxos[index].vout]
+      );
+
+      responderUtxos.forEach((utxo: any, index: number) => {
+        utxo.prevout = outputs[index];
+      });
+
+      // create the request tx using wallet
+      const responderWallet: Wallet = walletFromAddresses(
+        responder.getAddresses(),
+        'regtest'
+      );
+
+      const {
+        psetBase64,
         inputBlindingKeys,
         outputBlindingKeys,
+      } = responderWallet.updateTx(
+        txSwapRequest.toBase64(),
+        responderUtxos,
+        100_0000_0000,
+        1_0000_0000,
+        shitcoin,
+        network.assetHash,
+        responder.getNextAddress(),
+        responder.getNextChangeAddress()
+      );
+
+      assert.doesNotThrow(() => Psbt.fromBase64(psetBase64));
+
+      inputsKeys = { ...inputsKeys, ...inputBlindingKeys };
+      outputsKeys = { ...outputsKeys, ...outputBlindingKeys };
+
+      const swap = new Swap();
+      assert.doesNotThrow(() => {
+        swap.accept({
+          message: messageSwapRequest,
+          psbtBase64: psetBase64,
+          inputBlindingKeys: inputsKeys,
+          outputBlindingKeys: outputsKeys,
+        });
       });
-      // );
     });
   });
 });


### PR DESCRIPTION
This PR adds the file `wallet.test.ts`

it adds unit testing for transaction building + fix a type problem in `utils.ts` (Number -> number).

Note that we need to unblind the utxos before pass it to updateTx method (if it not the case, the function throws an error). Maybe we can do this step directly inside the updateTx. What's your opinion?

@tiero @altafan 

it closes #43 