### PR TITLE
use psetBase64 instead of psbtBase64

### DIFF
--- a/src/swap.ts
+++ b/src/swap.ts
@@ -20,7 +20,7 @@ interface requestOpts {
   amountToBeSent: number;
   assetToReceive: string;
   amountToReceive: number;
-  psbtBase64: string;
+  psetBase64: string;
   inputBlindingKeys?: BlindKeysMap;
   outputBlindingKeys?: BlindKeysMap;
 }
@@ -28,7 +28,7 @@ interface requestOpts {
 // define the Swap.accept arguments.
 interface acceptOpts {
   message: Uint8Array;
-  psbtBase64: string;
+  psetBase64: string;
   inputBlindingKeys?: BlindKeysMap;
   outputBlindingKeys?: BlindKeysMap;
 }
@@ -49,7 +49,7 @@ export class Swap extends Core {
     assetToBeSent,
     amountToReceive,
     assetToReceive,
-    psbtBase64,
+    psetBase64,
     inputBlindingKeys,
     outputBlindingKeys,
   }: requestOpts): Uint8Array {
@@ -60,7 +60,7 @@ export class Swap extends Core {
     msg.setAssetP(assetToBeSent);
     msg.setAmountR(amountToReceive);
     msg.setAssetR(assetToReceive);
-    msg.setTransaction(psbtBase64);
+    msg.setTransaction(psetBase64);
 
     if (inputBlindingKeys) {
       // set the input blinding keys
@@ -90,7 +90,7 @@ export class Swap extends Core {
    */
   accept({
     message,
-    psbtBase64,
+    psetBase64,
     inputBlindingKeys,
     outputBlindingKeys,
   }: acceptOpts): Uint8Array {
@@ -100,7 +100,7 @@ export class Swap extends Core {
     const msgAccept = new proto.SwapAccept();
     msgAccept.setId(makeid(8));
     msgAccept.setRequestId(msgRequest.getId());
-    msgAccept.setTransaction(psbtBase64);
+    msgAccept.setTransaction(psetBase64);
 
     if (inputBlindingKeys) {
       // set the input blinding keys
@@ -131,13 +131,13 @@ export class Swap extends Core {
    */
   complete({
     message,
-    psbtBase64,
+    psetBase64,
   }: {
     message: Uint8Array;
-    psbtBase64: string;
+    psetBase64: string;
   }): Uint8Array {
     //First validate signatures
-    const { psbt } = decodePsbt(psbtBase64);
+    const { psbt } = decodePsbt(psetBase64);
 
     if (!psbt.validateSignaturesOfAllInputs())
       throw new Error('Signatures not valid');
@@ -147,7 +147,7 @@ export class Swap extends Core {
     const msgComplete = new proto.SwapComplete();
     msgComplete.setId(makeid(8));
     msgComplete.setAcceptId(msgAccept.getId());
-    msgComplete.setTransaction(psbtBase64);
+    msgComplete.setTransaction(psetBase64);
 
     if (this.verbose) console.log(msgAccept.toObject());
 

--- a/src/trade.ts
+++ b/src/trade.ts
@@ -214,7 +214,7 @@ export class Trade extends Core implements TradeInterface {
       amountToBeSent,
       assetToReceive,
       amountToReceive,
-      psbtBase64: psetBase64,
+      psetBase64: psetBase64,
       inputBlindingKeys,
       outputBlindingKeys,
     });
@@ -244,7 +244,7 @@ export class Trade extends Core implements TradeInterface {
     const swap = new Swap();
     const swapCompleteSerialized = swap.complete({
       message: swapAcceptSerialized,
-      psbtBase64: signedPset,
+      psetBase64: signedPset,
     });
 
     // Trader call the tradeComplete endpoint to finalize the swap

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -85,11 +85,11 @@ export function makeid(length: number): string {
 }
 
 export function decodePsbt(
-  psbtBase64: string
+  psetBase64: string
 ): { psbt: Psbt; transaction: Transaction } {
   let psbt: Psbt;
   try {
-    psbt = Psbt.fromBase64(psbtBase64);
+    psbt = Psbt.fromBase64(psetBase64);
   } catch (ignore) {
     throw new Error('Invalid psbt');
   }

--- a/test/swap.test.ts
+++ b/test/swap.test.ts
@@ -15,13 +15,13 @@ describe('Swap', () => {
 
   describe('Swap Request message', () => {
     test('should create a valid SwapRequest message if transaction is unconfidential.', () => {
-      const psbtBase64 = initialPsbtOfAlice;
+      const psetBase64 = initialPsbtOfAlice;
       const bytes = swap.request({
         assetToBeSent: fixtures.assets.USDT,
         amountToBeSent: 30000000000,
         assetToReceive: fixtures.assets.LBTC,
         amountToReceive: 5000000,
-        psbtBase64,
+        psetBase64,
       });
 
       expect(bytes).toBeDefined();
@@ -34,11 +34,11 @@ describe('Swap', () => {
       amountToBeSent: 30000000000,
       assetToReceive: fixtures.assets.LBTC,
       amountToReceive: 5000000,
-      psbtBase64: initialPsbtOfAlice,
+      psetBase64: initialPsbtOfAlice,
     });
 
-    const psbtBase64 = initialPsbtOfBob;
-    const bytes = swap.accept({ message: swapRequestMessage, psbtBase64 });
+    const psetBase64 = initialPsbtOfBob;
+    const bytes = swap.accept({ message: swapRequestMessage, psetBase64 });
 
     expect(bytes).toBeDefined();
   });
@@ -49,17 +49,17 @@ describe('Swap', () => {
       amountToBeSent: 30000000000,
       assetToReceive: fixtures.assets.LBTC,
       amountToReceive: 5000000,
-      psbtBase64: initialPsbtOfAlice,
+      psetBase64: initialPsbtOfAlice,
     });
 
     const swapAcceptMessage = swap.accept({
       message: swapRequestMessage,
-      psbtBase64: initialPsbtOfBob,
+      psetBase64: initialPsbtOfBob,
     });
 
     const bytes = swap.complete({
       message: swapAcceptMessage,
-      psbtBase64: finalPsbtOfAlice,
+      psetBase64: finalPsbtOfAlice,
     });
 
     expect(bytes).toBeDefined();
@@ -92,7 +92,7 @@ describe('Swap', () => {
           amountToBeSent: fixture.toBeSent.amount,
           assetToReceive: fixture.toReceive.asset,
           amountToReceive: fixture.toReceive.amount,
-          psbtBase64: fixture.request.psbt,
+          psetBase64: fixture.request.psbt,
           inputBlindingKeys: inKeys,
           outputBlindingKeys: outKeys,
         });
@@ -123,7 +123,7 @@ describe('Swap', () => {
       // assertions
       assert.doesNotThrow(() => {
         acceptMessage = swap.accept({
-          psbtBase64: fixture.accept.psbt,
+          psetBase64: fixture.accept.psbt,
           message: requestMessage,
           inputBlindingKeys: inKeys,
           outputBlindingKeys: outKeys,
@@ -135,7 +135,7 @@ describe('Swap', () => {
       assert.doesNotThrow(() => {
         swap.complete({
           message: acceptMessage,
-          psbtBase64: fixtures.confidentialSwaps[0].complete.psbt,
+          psetBase64: fixtures.confidentialSwaps[0].complete.psbt,
         });
       });
     });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -118,7 +118,7 @@ describe('Wallet - Transaction builder', () => {
           assetToBeSent: network.assetHash,
           amountToReceive: 100_0000_0000,
           assetToReceive: shitcoin,
-          psbtBase64,
+          psetBase64: psbtBase64,
           inputBlindingKeys: inputsKeys,
           outputBlindingKeys: outputsKeys,
         });
@@ -200,7 +200,7 @@ describe('Wallet - Transaction builder', () => {
       assert.doesNotThrow(() => {
         swap.accept({
           message: messageSwapRequest,
-          psbtBase64,
+          psetBase64: psbtBase64,
           inputBlindingKeys: inputsKeys,
           outputBlindingKeys: outputsKeys,
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2594,9 +2594,9 @@ escodegen@^1.9.1:
     source-map "~0.6.1"
 
 eslint-config-prettier@^6.0.0:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.14.0.tgz#390e7863a8ae99970981933826476169285b3a27"
-  integrity sha512-DbVwh0qZhAC7CNDWcq8cBdK6FcVHiMTKmCypOPWeZkp9hJ8xYwTaWSa6bb6cjfi8KOeJy0e9a8Izxyx+O4+gCQ==
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz#7f93f6cb7d45a92f1537a70ecc06366e1ac6fed9"
+  integrity sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -3130,9 +3130,9 @@ gaxios@^3.0.0:
     node-fetch "^2.3.0"
 
 gaxios@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-4.0.0.tgz#eb01a923d5fd920174f05f9ccd4c743032c177a6"
-  integrity sha512-Ge+S+8L8xe/LAjC2tHXFuBMVhjjm4sMevjEHshJeMZ0d37fspa9BO8WEMlYxk4lyydR/v63iHWZZ1Ri7hAqzSg==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-4.0.1.tgz#bc7b205a89d883452822cc75e138620c35e3291e"
+  integrity sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==
   dependencies:
     abort-controller "^3.0.0"
     extend "^3.0.2"
@@ -3149,9 +3149,9 @@ gcp-metadata@^4.2.0:
     json-bigint "^1.0.0"
 
 gensync@^1.0.0-beta.1:
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
-  integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
 get-caller-file@^2.0.1:
   version "2.0.5"


### PR DESCRIPTION
This changes the public API for `Swap` module, where the now we use  `psetBase64` instead of old `psbtBase64`