### PR TITLE
[HOT-FIX] update the index of mnemonic when restored

### DIFF
--- a/test/mnemonic.identity.test.ts
+++ b/test/mnemonic.identity.test.ts
@@ -242,5 +242,31 @@ describe('Identity: Private key', () => {
           .sort()
       );
     });
+
+    it('should update the index when restored', () => {
+      const addressesKnown = toRestoreMnemonic
+        .getAddresses()
+        .map(a => a.confidentialAddress);
+
+      const next = toRestoreMnemonic.getNextAddress();
+      const nextIsAlreadyKnownByMnemonic = addressesKnown.includes(
+        next.confidentialAddress
+      );
+
+      assert.deepStrictEqual(nextIsAlreadyKnownByMnemonic, false);
+    });
+
+    it('should update the change index when restored', () => {
+      const addressesKnown = toRestoreMnemonic
+        .getAddresses()
+        .map(a => a.confidentialAddress);
+
+      const next = toRestoreMnemonic.getNextChangeAddress();
+      const nextIsAlreadyKnownByMnemonic = addressesKnown.includes(
+        next.confidentialAddress
+      );
+
+      assert.deepStrictEqual(nextIsAlreadyKnownByMnemonic, false);
+    });
   });
 });


### PR DESCRIPTION
**This PR fixes a bug with Mnemonic restoration**

Now, it updates the `index` and `changeIndex` of the Mnemonic when we restore it.
It also adds tests for that in `mnemonic.identity.test.ts`

@tiero please review