### PR TITLE
Reject in case of SwapFail

### DIFF
--- a/src/grpcClient.ts
+++ b/src/grpcClient.ts
@@ -48,7 +48,7 @@ export class TraderClient implements TraderClientInterface {
       const call = this.client.tradePropose(request);
       let data: Uint8Array;
       call.on('data', (reply: messages.TradeProposeReply) => {
-        throwErrorIfSwapFail(reply);
+        rejectIfSwapFail(reply, reject);
         const swapAcceptMsg = reply!.getSwapAccept();
         data = swapAcceptMsg!.serializeBinary();
       });
@@ -71,7 +71,7 @@ export class TraderClient implements TraderClientInterface {
       const call = this.client.tradeComplete(request);
       let data: string;
       call.on('data', (reply: messages.TradeCompleteReply) => {
-        throwErrorIfSwapFail(reply);
+        rejectIfSwapFail(reply, reject);
         data = reply!.getTxid();
       });
       call.on('end', () => resolve(data));
@@ -160,12 +160,13 @@ export class TraderClient implements TraderClientInterface {
   }
 }
 
-export function throwErrorIfSwapFail(
-  tradeReply: messages.TradeProposeReply | messages.TradeCompleteReply
+export function rejectIfSwapFail(
+  tradeReply: messages.TradeProposeReply | messages.TradeCompleteReply,
+  reject: (reason?: any) => void
 ) {
   const swapFail = tradeReply.getSwapFail();
   if (swapFail) {
     const errorMessage = `SwapFail for message id=${swapFail.getId()}. Failure code ${swapFail.getFailureCode()} | reason: ${swapFail.getFailureMessage()}`;
-    throw new Error(errorMessage);
+    reject(errorMessage);
   }
 }

--- a/src/grpcClient.ts
+++ b/src/grpcClient.ts
@@ -3,8 +3,8 @@ import * as services from 'tdex-protobuf/generated/js/trade_grpc_pb';
 import * as messages from 'tdex-protobuf/generated/js/trade_pb';
 import * as types from 'tdex-protobuf/generated/js/types_pb';
 import { SwapRequest, SwapComplete } from 'tdex-protobuf/generated/js/swap_pb';
-
 import TraderClientInterface from './grpcClientInterface';
+import { rejectIfSwapFail } from './utils';
 
 export class TraderClient implements TraderClientInterface {
   providerUrl: string;
@@ -157,16 +157,5 @@ export class TraderClient implements TraderClientInterface {
         resolve(reply);
       });
     });
-  }
-}
-
-export function rejectIfSwapFail(
-  tradeReply: messages.TradeProposeReply | messages.TradeCompleteReply,
-  reject: (reason?: any) => void
-) {
-  const swapFail = tradeReply.getSwapFail();
-  if (swapFail) {
-    const errorMessage = `SwapFail for message id=${swapFail.getId()}. Failure code ${swapFail.getFailureCode()} | reason: ${swapFail.getFailureMessage()}`;
-    reject(errorMessage);
   }
 }

--- a/src/grpcClient.web.ts
+++ b/src/grpcClient.web.ts
@@ -2,10 +2,8 @@ import * as services from 'tdex-protobuf/generated/js/TradeServiceClientPb';
 import * as messages from 'tdex-protobuf/generated/js/trade_pb';
 import * as types from 'tdex-protobuf/generated/js/types_pb';
 import { SwapRequest, SwapComplete } from 'tdex-protobuf/generated/js/swap_pb';
-
 import TraderClientInterface from './grpcClientInterface';
-
-import { getClearTextTorProxyUrl } from './utils';
+import { getClearTextTorProxyUrl, rejectIfSwapFail } from './utils';
 
 export class TraderClient implements TraderClientInterface {
   providerUrl: string;
@@ -56,7 +54,7 @@ export class TraderClient implements TraderClientInterface {
 
       let data: Uint8Array;
       call.on('data', (reply: messages.TradeProposeReply) => {
-        reject(reply);
+        rejectIfSwapFail(reply, reject);
         const swapAcceptMsg = reply!.getSwapAccept();
         data = swapAcceptMsg!.serializeBinary();
       });
@@ -79,7 +77,7 @@ export class TraderClient implements TraderClientInterface {
       const call = this.client.tradeComplete(request);
       let data: string;
       call.on('data', (reply: messages.TradeCompleteReply) => {
-        reject(reply);
+        rejectIfSwapFail(reply, reject);
         data = reply!.getTxid();
       });
       call.on('end', () => resolve(data));

--- a/src/grpcClient.web.ts
+++ b/src/grpcClient.web.ts
@@ -56,7 +56,7 @@ export class TraderClient implements TraderClientInterface {
 
       let data: Uint8Array;
       call.on('data', (reply: messages.TradeProposeReply) => {
-        throwErrorIfSwapFail(reply);
+        reject(reply);
         const swapAcceptMsg = reply!.getSwapAccept();
         data = swapAcceptMsg!.serializeBinary();
       });
@@ -79,7 +79,7 @@ export class TraderClient implements TraderClientInterface {
       const call = this.client.tradeComplete(request);
       let data: string;
       call.on('data', (reply: messages.TradeCompleteReply) => {
-        throwErrorIfSwapFail(reply);
+        reject(reply);
         data = reply!.getTxid();
       });
       call.on('end', () => resolve(data));
@@ -169,15 +169,5 @@ export class TraderClient implements TraderClientInterface {
         resolve(reply);
       });
     });
-  }
-}
-
-export function throwErrorIfSwapFail(
-  tradeReply: messages.TradeProposeReply | messages.TradeCompleteReply
-) {
-  const swapFail = tradeReply.getSwapFail();
-  if (swapFail) {
-    const errorMessage = `SwapFail for message id=${swapFail.getId()}. Failure code ${swapFail.getFailureCode()} | reason: ${swapFail.getFailureMessage()}`;
-    throw new Error(errorMessage);
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import { Psbt, Transaction } from 'liquidjs-lib';
+import * as messages from 'tdex-protobuf/generated/js/trade_pb';
 
 /**
  * Generates a random id of a fixed length.
@@ -43,4 +44,20 @@ export function getClearTextTorProxyUrl(
   const onionPubKey = splitted.join('.');
 
   return `${torProxyEndpoint}/${onionPubKey}`;
+}
+
+/**
+ * used to inspect TradePropose or TradeComplete reply messages
+ * @param tradeReply TradePropose or TradeComplete protobuf messages
+ * @param reject the promise's reject function
+ */
+export function rejectIfSwapFail(
+  tradeReply: messages.TradeProposeReply | messages.TradeCompleteReply,
+  reject: (reason?: any) => void
+) {
+  const swapFail = tradeReply.getSwapFail();
+  if (swapFail) {
+    const errorMessage = `SwapFail for message id=${swapFail.getId()}. Failure code ${swapFail.getFailureCode()} | reason: ${swapFail.getFailureMessage()}`;
+    reject(errorMessage);
+  }
 }

--- a/test/trade.test.ts
+++ b/test/trade.test.ts
@@ -6,7 +6,7 @@ import {
   UtxoInterface,
 } from 'ldk';
 import * as TDEX from '../src/index';
-import { Trade, IdentityType, throwErrorIfSwapFail } from '../src/index';
+import { Trade, IdentityType, rejectIfSwapFail } from '../src/index';
 import {
   TradeCompleteReply,
   TradeProposeReply,
@@ -82,12 +82,20 @@ describe('TDEX SDK', () => {
       const tradeProposeReplyWithoutSwapFail = new TradeProposeReply();
 
       it('should throw an error if there is SwapFail in TradeProposeReply', () => {
-        assert.throws(() => throwErrorIfSwapFail(tradeProposeReply));
+        assert.rejects(
+          () =>
+            new Promise((_, reject) =>
+              rejectIfSwapFail(tradeProposeReply, reject)
+            )
+        );
       });
 
       it('should not throw an error if there is no SwapFail in TradeProposeReply', () => {
-        assert.doesNotThrow(() =>
-          throwErrorIfSwapFail(tradeProposeReplyWithoutSwapFail)
+        assert.doesNotReject(
+          () =>
+            new Promise((_, reject) =>
+              rejectIfSwapFail(tradeProposeReplyWithoutSwapFail, reject)
+            )
         );
       });
     });
@@ -99,12 +107,20 @@ describe('TDEX SDK', () => {
       const tradeCompleteReplyWithoutSwapFail = new TradeCompleteReply();
 
       it('should throw an error if there is SwapFail in TradeCompleteReply', () => {
-        assert.throws(() => throwErrorIfSwapFail(tradeCompleteReply));
+        assert.rejects(
+          () =>
+            new Promise((_, reject) =>
+              rejectIfSwapFail(tradeCompleteReply, reject)
+            )
+        );
       });
 
       it('should not throw an error if there is no SwapFail in TradeCompleteReply', () => {
-        assert.doesNotThrow(() =>
-          throwErrorIfSwapFail(tradeCompleteReplyWithoutSwapFail)
+        assert.doesNotReject(
+          () =>
+            new Promise((_, reject) =>
+              rejectIfSwapFail(tradeCompleteReplyWithoutSwapFail, reject)
+            )
         );
       });
     });

--- a/test/trade.test.ts
+++ b/test/trade.test.ts
@@ -6,7 +6,7 @@ import {
   UtxoInterface,
 } from 'ldk';
 import * as TDEX from '../src/index';
-import { Trade, IdentityType, rejectIfSwapFail } from '../src/index';
+import { Trade, IdentityType } from '../src/index';
 import {
   TradeCompleteReply,
   TradeProposeReply,
@@ -14,6 +14,7 @@ import {
 import { SwapFail } from 'tdex-protobuf/generated/js/swap_pb';
 import * as assert from 'assert';
 import { faucet, sleep } from './_regtest';
+import { rejectIfSwapFail } from '../src/utils';
 
 jest.setTimeout(30000);
 


### PR DESCRIPTION
This PR uses the `rejectIfSwapFail` function to check if a TradePropose or a TradeComplete message contains a SwapFail: if yes reject the parent promise + update unit tests.

it closes #82 

@tiero please review 
