### PR TITLE
Update script for Nigiri v0.2.1

### DIFF
--- a/scripts/tdexd-run-mac
+++ b/scripts/tdexd-run-mac
@@ -5,14 +5,28 @@ set -e
 echo ""
 echo "starting tdexd"
 
+TDEX_BASE_ASSET="5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225"
+
+while getopts a: flag
+do
+  case "${flag}" in
+    a) TDEX_BASE_ASSET=${OPTARG};;
+    *) echo "usage: $0 [-a TDEX_BASE_ASSET]" >&2
+       exit 1 ;;
+  esac
+done
+
+echo "TDEX_BASE_ASSET: $TDEX_BASE_ASSET";
+echo ""
+
 docker run -it -d --name tdexd \
 -p 9945:9945 -p 9000:9000 \
 -v "$(pwd)/tdexd:/.tdex-daemon" \
 -e TDEX_NETWORK="regtest" \
--e TDEX_BASE_ASSET="5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225" \
--e TDEX_EXPLORER_ENDPOINT="http://10.10.0.17:3000" \
+-e TDEX_BASE_ASSET="$TDEX_BASE_ASSET" \
+-e TDEX_EXPLORER_ENDPOINT="http://chopsticks-liquid:3000" \
 -e TDEX_NO_MACAROONS=true \
---network="resources_local" \
+--network="nigiri" \
 ghcr.io/tdex-network/tdexd:latest
 
 echo ""
@@ -101,7 +115,7 @@ echo "market quote outpoint 1: ${shittxid1} ${shitvout1}"
 echo "market quote outpoint 2: ${shittxid2} ${shitvout2}"
 echo "market quote outpoint 3: ${shittxid3} ${shitvout3}"
 
-$tdex config set base_asset 5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225 &>/dev/null
+$tdex config set base_asset $TDEX_BASE_ASSET &>/dev/null
 $tdex config set quote_asset $shitcoin &>/dev/null
 
 $tdex claimmarket --outpoints '[{"hash":"'$btctxid'", "index":'$btcvout'}, {"hash":"'$shittxid1'", "index":'$shitvout1'}, {"hash":"'$shittxid2'", "index":'$shitvout2'}, {"hash":"'$shittxid3'", "index":'$shitvout3'}]'
@@ -111,4 +125,4 @@ echo ""
 echo "opening market"
 $tdex open
 
-echo '{"market": {"baseAsset": "5ac9f65c0efcc4775e0baec4ec03abdde22473cd3cf33c0419ca290e0751b225","quoteAsset": "'$shitcoin'"}} ' >./test/fixtures/trade.integration.json
+echo '{"market": {"baseAsset": "'$TDEX_BASE_ASSET'","quoteAsset": "'$shitcoin'"}} ' >./test/fixtures/trade.integration.json


### PR DESCRIPTION
Script now accept custom base asset hash through optional argument `-a`, defaulting to usual hash.
Fix networking.

Please review @tiero 