### PR TITLE
Add `Discoverer` class, useful to discover best TDEX providers

### DIFF
--- a/src/discoverer.ts
+++ b/src/discoverer.ts
@@ -1,0 +1,28 @@
+import { Discovery, DiscoveryOpts } from 'discovery';
+import TraderClientInterface from 'grpcClientInterface';
+
+export interface DiscovererInterface {
+  clients: TraderClientInterface[];
+  discovery: Discovery;
+  discover(opts: DiscoveryOpts): Promise<TraderClientInterface[]>;
+}
+
+export class Discoverer implements DiscovererInterface {
+  clients: TraderClientInterface[];
+  discovery: Discovery;
+  errorHandler?: (err: any) => Promise<void>;
+
+  constructor(
+    clients: TraderClientInterface[],
+    discovery: Discovery,
+    errorHandler?: (err: any) => Promise<void>
+  ) {
+    this.clients = clients;
+    this.discovery = discovery;
+    this.errorHandler = errorHandler;
+  }
+
+  async discover(opts: DiscoveryOpts): Promise<TraderClientInterface[]> {
+    return this.discovery(this.clients, opts, this.errorHandler);
+  }
+}

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -1,0 +1,77 @@
+import { MarketInterface, TradeType } from 'tradeCore';
+import TraderClientInterface from './grpcClientInterface';
+
+export interface DiscoveryOpts {
+  market: MarketInterface;
+  amount: number;
+  asset: string;
+  type: TradeType;
+}
+
+export type Discovery = (
+  clients: TraderClientInterface[],
+  discoveryOpts: DiscoveryOpts,
+  errorHandler?: (err: any) => Promise<void>
+) => Promise<TraderClientInterface[]>;
+
+// combine several discoveries function
+// each function will be applied in the order specified in discoveries
+export function combineDiscovery(...discoveries: Discovery[]): Discovery {
+  return async (
+    clients: TraderClientInterface[],
+    opts: DiscoveryOpts,
+    errorHandler?: (err: any) => Promise<void>
+  ) => {
+    let results = clients;
+    for (const discovery of discoveries) {
+      if (results.length <= 1) return results;
+      results = await discovery(results, opts, errorHandler);
+    }
+
+    return results;
+  };
+}
+
+// bestBalanceDiscovery returns the clients with the greater balance.
+// according to trade's type: BUY = max base balance, SELL = max quote balance.
+export const bestBalanceDiscovery: Discovery = async (
+  clients: TraderClientInterface[],
+  opts: DiscoveryOpts,
+  errorHandler?: (err: any) => Promise<void>
+) => {
+  const balancesPromises = clients.map(client => client.balances(opts.market));
+  const balancesPromisesResults = await Promise.allSettled(balancesPromises);
+
+  let bestTraders: TraderClientInterface[] = [];
+  let maxAmount = 0;
+
+  let index = 0;
+  for (const result of balancesPromisesResults) {
+    if (result.status === 'fulfilled') {
+      const balance = result.value[0].balance;
+      if (!balance) {
+        if (errorHandler)
+          await errorHandler('unknown error, balance is undefined');
+        continue;
+      }
+
+      const amount =
+        opts.type === TradeType.BUY ? balance.baseAmount : balance.quoteAmount;
+
+      if (maxAmount < amount) {
+        maxAmount = amount;
+        bestTraders = [clients[index]];
+      }
+
+      if (amount === maxAmount) {
+        bestTraders.push(clients[index]);
+      }
+    } else if (result.status === 'rejected' && errorHandler) {
+      await errorHandler(result.reason);
+    }
+
+    index++;
+  }
+
+  return bestTraders;
+};

--- a/src/grpcClient.web.ts
+++ b/src/grpcClient.web.ts
@@ -151,7 +151,7 @@ export class TraderClient implements TraderClientInterface {
   }: {
     baseAsset: string;
     quoteAsset: string;
-  }): Promise<Array<types.BalanceWithFee.AsObject>> {
+  }): Promise<types.BalanceWithFee.AsObject[]> {
     const market = new types.Market();
     market.setBaseAsset(baseAsset);
     market.setQuoteAsset(quoteAsset);

--- a/src/grpcClientInterface.ts
+++ b/src/grpcClientInterface.ts
@@ -1,4 +1,7 @@
-import { BalanceWithFee } from 'tdex-protobuf/generated/js/types_pb';
+import {
+  BalanceWithFee,
+  PriceWithFee,
+} from 'tdex-protobuf/generated/js/types_pb';
 
 export default interface TraderClientInterface {
   providerUrl: string;
@@ -29,14 +32,7 @@ export default interface TraderClientInterface {
     tradeType: number,
     amount: number,
     asset: string
-  ): Promise<
-    Array<{
-      price?: { basePrice: number; quotePrice: number };
-      fee?: { basisPoint: number };
-      amount: number;
-      asset: string;
-    }>
-  >;
+  ): Promise<PriceWithFee.AsObject[]>;
   balances({
     baseAsset,
     quoteAsset,

--- a/src/grpcClientInterface.ts
+++ b/src/grpcClientInterface.ts
@@ -1,3 +1,5 @@
+import { BalanceWithFee } from 'tdex-protobuf/generated/js/types_pb';
+
 export default interface TraderClientInterface {
   providerUrl: string;
   client: any;
@@ -41,10 +43,5 @@ export default interface TraderClientInterface {
   }: {
     baseAsset: string;
     quoteAsset: string;
-  }): Promise<
-    Array<{
-      balance?: { baseAmount: number; quoteAmount: number };
-      fee?: { basisPoint: number };
-    }>
-  >;
+  }): Promise<BalanceWithFee.AsObject[]>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,5 @@ export * from './tradeCore';
 export * from './grpcClient';
 export * from './transaction';
 export * from './tdexMnemonic';
+export * from './discoverer';
+export * from './discovery';

--- a/test/discoverer.test.ts
+++ b/test/discoverer.test.ts
@@ -1,0 +1,78 @@
+import MockTraderClientInterface from './fixtures/mockTraderClientInterface';
+import { Discoverer, DiscovererInterface } from '../src/discoverer';
+import { bestBalanceDiscovery, bestPriceDiscovery } from '../src/discovery';
+import { TradeType } from '../src/tradeCore';
+import assert from 'assert';
+import TraderClientInterface from '../src/grpcClientInterface';
+
+describe('discoverer', () => {
+  let trader1: TraderClientInterface,
+    trader2: TraderClientInterface,
+    trader3: TraderClientInterface;
+  let bestBalanceDiscoverer: DiscovererInterface;
+  let bestPriceDiscoverer: DiscovererInterface;
+
+  beforeAll(() => {
+    trader1 = new MockTraderClientInterface({
+      providerUrl: 'trader1',
+      balance: { balance: { baseAmount: 1, quoteAmount: 1000 } },
+      price: { amount: 10, asset: '' },
+    });
+    trader2 = new MockTraderClientInterface({
+      providerUrl: 'trader2',
+      balance: { balance: { baseAmount: 10, quoteAmount: 10 } },
+      price: { amount: 100, asset: '' },
+    });
+    trader3 = new MockTraderClientInterface({
+      providerUrl: 'trader3',
+      balance: { balance: { baseAmount: 100, quoteAmount: 100 } },
+      price: { amount: 1000, asset: '' },
+    });
+
+    bestBalanceDiscoverer = new Discoverer(
+      [trader1, trader2, trader3],
+      bestBalanceDiscovery
+    );
+    bestPriceDiscoverer = new Discoverer(
+      [trader1, trader2, trader3],
+      bestPriceDiscovery
+    );
+  });
+
+  describe('best balance', () => {
+    test('should select the balance with the greater amount (TradeType BUY)', async () => {
+      const best = await bestBalanceDiscoverer.discover({
+        type: TradeType.BUY,
+        market: { quoteAsset: '', baseAsset: '' },
+        amount: 12,
+        asset: '',
+      });
+      assert.strictEqual(best.length, 1);
+      assert.strictEqual(best[0], trader3);
+    });
+
+    test('should select the balance with the greater amount (TradeType SELL)', async () => {
+      const best = await bestBalanceDiscoverer.discover({
+        type: TradeType.SELL,
+        market: { quoteAsset: '', baseAsset: '' },
+        amount: 12,
+        asset: '',
+      });
+      assert.strictEqual(best.length, 1);
+      assert.strictEqual(best[0], trader1);
+    });
+  });
+
+  describe('best price', () => {
+    test('should select the price with the greater amount (= the lowest price)', async () => {
+      const best = await bestPriceDiscoverer.discover({
+        type: TradeType.BUY,
+        market: { quoteAsset: '', baseAsset: '' },
+        amount: 12,
+        asset: '',
+      });
+      assert.strictEqual(best.length, 1);
+      assert.strictEqual(best[0], trader3);
+    });
+  });
+});

--- a/test/fixtures/mockTraderClientInterface.ts
+++ b/test/fixtures/mockTraderClientInterface.ts
@@ -1,0 +1,58 @@
+import {
+  PriceWithFee,
+  BalanceWithFee,
+} from 'tdex-protobuf/generated/js/types_pb';
+import TraderClientInterface from '../../src/grpcClientInterface';
+
+interface Args {
+  balance?: BalanceWithFee.AsObject;
+  price?: PriceWithFee.AsObject;
+  providerUrl?: string;
+}
+
+export default class MockTraderClientInterface
+  implements TraderClientInterface {
+  balance?: BalanceWithFee.AsObject;
+  price?: PriceWithFee.AsObject;
+
+  providerUrl: string;
+  client: any;
+
+  constructor({ balance, price, providerUrl }: Args) {
+    this.balance = balance;
+    this.price = price;
+    this.providerUrl = providerUrl ?? '';
+  }
+
+  tradePropose(
+    _: { baseAsset: string; quoteAsset: string },
+    __: number,
+    ___: Uint8Array
+  ): Promise<Uint8Array> {
+    throw new Error('Method not implemented.');
+  }
+  tradeComplete(_: Uint8Array): Promise<string> {
+    throw new Error('Method not implemented.');
+  }
+  markets(): Promise<
+    { baseAsset: string; quoteAsset: string; feeBasisPoint: number }[]
+  > {
+    throw new Error('Method not implemented.');
+  }
+  marketPrice(
+    _: { baseAsset: string; quoteAsset: string },
+    __: number,
+    ___: number,
+    ____: string
+  ): Promise<PriceWithFee.AsObject[]> {
+    if (!this.price) throw new Error('u need to set up a mocked price');
+    return Promise.resolve([this.price]);
+  }
+  balances(_: {
+    baseAsset: string;
+    quoteAsset: string;
+  }): Promise<BalanceWithFee.AsObject[]> {
+    if (!this.balance) throw new Error('u need to set up a mocked balance');
+    return Promise.resolve([this.balance]);
+  }
+}


### PR DESCRIPTION
**This PR adds two files `src/discoverer.ts` and `src/discovery.ts`** 

- `Discoverer` takes a list of `TraderClientInterface` corresponding to the trader clients connected to a set of providers. It also needs a `Discovery` (= a typed function) in order to set the strategy of the Discoverer.
- There is two exported discovery: `bestBalanceDiscovery` which selects the greater balance of the providers. And `bestPriceDiscovery` for the price.
- We can combine Discovery strategies using `combineDiscoveries` function.
- add a new test file for Discoverer and default discoveries.

### Usage

```typescript
const discoverer = new Discoverer(
  [trader1, trader2, trader3],
  bestBalanceDiscovery,
  (error: any) => console.error(error) // optional async error handler
);

const bestBalanceClientInterface = (await discoverer.discover({
    type: TradeType.BUY,
    market: { quoteAsset: 'asset1', baseAsset: 'asset2' },
    amount: 12,
    asset: 'asset1',
}))[0];
```

**Why `Discovery` function returns an array?**
it lets to handle equality cases. For instance, if two providers provide the same price in `bestPriceDiscovery`.

**Why `Discoverer` do not use JSON registry format?**
The idea is to be more flexible, for instance in tdex-app we only use the registry format the first time while we fetch it. `TraderClientInterface` lets to handle all the cases. PS: We could add a utility static constructor function in Discoverer: `Discoverer.fromRegistry(registry, discovery)`.

it closes #102 

@tiero please review