### PR TITLE
Fix fallback to server-side stream methods

### DIFF
--- a/src/tradeCore.ts
+++ b/src/tradeCore.ts
@@ -214,12 +214,16 @@ export class TradeCore extends Core implements TradeInterface {
         tradeType,
         swapRequestSerialized
       );
-    } catch (ignore) {
-      swapAcceptSerialized = await this.grpcClient.tradePropose(
-        market,
-        tradeType,
-        swapRequestSerialized
-      );
+    } catch (e) {
+      if ((e as any).code && (e as any).code === 12) {
+        swapAcceptSerialized = await this.grpcClient.tradePropose(
+          market,
+          tradeType,
+          swapRequestSerialized
+        );
+      } else {
+        throw e;
+      }
     }
 
     return swapAcceptSerialized;
@@ -249,8 +253,12 @@ export class TradeCore extends Core implements TradeInterface {
     let txid: string;
     try {
       txid = await this.grpcClient.completeTrade(swapCompleteSerialized);
-    } catch (ignore) {
-      txid = await this.grpcClient.tradeComplete(swapCompleteSerialized);
+    } catch (e) {
+      if ((e as any).code && (e as any).code === 12) {
+        txid = await this.grpcClient.tradeComplete(swapCompleteSerialized);
+      } else {
+        throw e;
+      }
     }
 
     return txid;


### PR DESCRIPTION
This explicitly check for UNIMPLEMENTED errors raised by either grpc client's proposeTrade or completeTrade methods in order to fallback to tradePropose or tradeComplete respectively.

Please @tiero review this.