### PR TITLE
Enrich discoverer API with TradeOrder type

### DIFF
--- a/src/discoverer.ts
+++ b/src/discoverer.ts
@@ -1,28 +1,28 @@
-import { Discovery, DiscoveryOpts } from 'discovery';
-import TraderClientInterface from 'grpcClientInterface';
+import { Discovery, DiscoveryOpts } from './discovery';
+import { TradeOrder } from './tradeCore';
 
 export interface DiscovererInterface {
-  clients: TraderClientInterface[];
+  orders: TradeOrder[];
   discovery: Discovery;
-  discover(opts: DiscoveryOpts): Promise<TraderClientInterface[]>;
+  discover(opts: DiscoveryOpts): Promise<TradeOrder[]>;
 }
 
 export class Discoverer implements DiscovererInterface {
-  clients: TraderClientInterface[];
+  orders: TradeOrder[];
   discovery: Discovery;
   errorHandler?: (err: any) => Promise<void>;
 
   constructor(
-    clients: TraderClientInterface[],
+    orders: TradeOrder[],
     discovery: Discovery,
     errorHandler?: (err: any) => Promise<void>
   ) {
-    this.clients = clients;
+    this.orders = orders;
     this.discovery = discovery;
     this.errorHandler = errorHandler;
   }
 
-  async discover(opts: DiscoveryOpts): Promise<TraderClientInterface[]> {
-    return this.discovery(this.clients, opts, this.errorHandler);
+  async discover(opts: DiscoveryOpts): Promise<TradeOrder[]> {
+    return this.discovery(this.orders, opts, this.errorHandler);
   }
 }

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -43,7 +43,10 @@ export const bestBalanceDiscovery: Discovery = async (
       .balances(market)
       .then((balances: BalanceWithFee.AsObject[]) => {
         const balance = balances[0].balance;
-        if (!balance) throw new Error('unknow error');
+        if (!balance)
+          throw new Error(
+            `no balances for market ${market.baseAsset}/${market.quoteAsset} using provider: ${traderClient.providerUrl}`
+          );
         const balanceAmount =
           type === TradeType.BUY ? balance.baseAmount : balance.quoteAmount;
         return {

--- a/src/tradeCore.ts
+++ b/src/tradeCore.ts
@@ -9,9 +9,16 @@ import {
 import TraderClientInterface from './grpcClientInterface';
 import { SwapAccept } from 'tdex-protobuf/generated/js/swap_pb';
 import { SwapTransaction } from './transaction';
+
 export interface MarketInterface {
   baseAsset: string;
   quoteAsset: string;
+}
+
+export interface TradeOrder {
+  type: TradeType;
+  market: MarketInterface;
+  traderClient: TraderClientInterface;
 }
 
 export interface TradeInterface extends CoreInterface {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,0 @@
-/**
- * Defines the shape of the object returned by the getAdresses's method.
- * @member confidentialAddress the confidential address.
- * @member blindingPrivateKey the blinding private key associated to the confidential address.
- */
-export interface AddressInterface {
-  confidentialAddress: string;
-  blindingPrivateKey: string;
-}

--- a/test/discoverer.test.ts
+++ b/test/discoverer.test.ts
@@ -1,16 +1,22 @@
 import MockTraderClientInterface from './fixtures/mockTraderClientInterface';
-import { Discoverer, DiscovererInterface } from '../src/discoverer';
+import { Discoverer } from '../src/discoverer';
 import { bestBalanceDiscovery, bestPriceDiscovery } from '../src/discovery';
-import { TradeType } from '../src/tradeCore';
+import { TradeOrder, TradeType } from '../src/tradeCore';
 import assert from 'assert';
 import TraderClientInterface from '../src/grpcClientInterface';
+
+const makeOrder = (type: TradeType) => (
+  trader: TraderClientInterface
+): TradeOrder => ({
+  traderClient: trader,
+  market: { quoteAsset: '', baseAsset: '' },
+  type,
+});
 
 describe('discoverer', () => {
   let trader1: TraderClientInterface,
     trader2: TraderClientInterface,
     trader3: TraderClientInterface;
-  let bestBalanceDiscoverer: DiscovererInterface;
-  let bestPriceDiscoverer: DiscovererInterface;
 
   beforeAll(() => {
     trader1 = new MockTraderClientInterface({
@@ -18,61 +24,63 @@ describe('discoverer', () => {
       balance: { balance: { baseAmount: 1, quoteAmount: 1000 } },
       price: { amount: 10, asset: '' },
     });
+
     trader2 = new MockTraderClientInterface({
       providerUrl: 'trader2',
       balance: { balance: { baseAmount: 10, quoteAmount: 10 } },
       price: { amount: 100, asset: '' },
     });
+
     trader3 = new MockTraderClientInterface({
       providerUrl: 'trader3',
       balance: { balance: { baseAmount: 100, quoteAmount: 100 } },
       price: { amount: 1000, asset: '' },
     });
-
-    bestBalanceDiscoverer = new Discoverer(
-      [trader1, trader2, trader3],
-      bestBalanceDiscovery
-    );
-    bestPriceDiscoverer = new Discoverer(
-      [trader1, trader2, trader3],
-      bestPriceDiscovery
-    );
   });
 
   describe('best balance', () => {
     test('should select the balance with the greater amount (TradeType BUY)', async () => {
+      const bestBalanceDiscoverer = new Discoverer(
+        [trader1, trader2, trader3].map(makeOrder(TradeType.BUY)),
+        bestBalanceDiscovery
+      );
+
       const best = await bestBalanceDiscoverer.discover({
-        type: TradeType.BUY,
-        market: { quoteAsset: '', baseAsset: '' },
         amount: 12,
         asset: '',
       });
       assert.strictEqual(best.length, 1);
-      assert.strictEqual(best[0], trader3);
+      assert.strictEqual(best[0].traderClient, trader3);
     });
 
     test('should select the balance with the greater amount (TradeType SELL)', async () => {
+      const bestBalanceDiscoverer = new Discoverer(
+        [trader1, trader2, trader3].map(makeOrder(TradeType.SELL)),
+        bestBalanceDiscovery
+      );
+
       const best = await bestBalanceDiscoverer.discover({
-        type: TradeType.SELL,
-        market: { quoteAsset: '', baseAsset: '' },
         amount: 12,
         asset: '',
       });
       assert.strictEqual(best.length, 1);
-      assert.strictEqual(best[0], trader1);
+      assert.strictEqual(best[0].traderClient, trader1);
     });
   });
 
   describe('best price', () => {
     test('should select the price with the greater amount (= the lowest price)', async () => {
+      const bestPriceDiscoverer = new Discoverer(
+        [trader1, trader2, trader3].map(makeOrder(TradeType.BUY)),
+        bestPriceDiscovery
+      );
+
       const best = await bestPriceDiscoverer.discover({
-        type: TradeType.BUY,
-        market: { quoteAsset: '', baseAsset: '' },
         amount: 12,
         asset: '',
       });
       assert.strictEqual(best.length, 1);
-      assert.strictEqual(best[0], trader3);
+      assert.strictEqual(best[0].traderClient, trader3);
     });
   });
 });


### PR DESCRIPTION
The current Discoverer/Discovery API lets to find the best trader interface according to `DiscoveryOpts` and a set of TraderClientInterface: this API limits the compare functions to a unique market/trade type. Making impossible to compare different markets (or different trade types) in the same `Discoverer`

This PR introduces the `TradeOrder` type which replace the `TraderClientInterface` in `discover` methods. A trade order is defined by:
- a market (base + quote asset)
- a trader client (`TraderClientInterface`)
- the trade type (BUY or SELL)

it basically let to handle discovery on different Trade type. The motivation behind this is the [base asset tdex-app issue ](https://github.com/tdex-network/tdex-app/issues/444): now, discoveries functions can handle comparison between a BUY on market (A, B) and a SELL on market (B, A).

BONUS: remove `types.ts` file (not used)

@tiero please review

