### PR TITLE
add export discoverer and discovery in index.web file

### DIFF
--- a/src/index.web.ts
+++ b/src/index.web.ts
@@ -5,3 +5,5 @@ export * from './tradeCore';
 export * from './grpcClient.web';
 export * from './transaction';
 export * from './tdexMnemonic';
+export * from './discoverer';
+export * from './discovery';


### PR DESCRIPTION
hotfix: `index.web.ts` does not export `discoverer.ts` and `discovery.ts` members.

@tiero please review