### PR TITLE
[BestPrice Discovery] Throw error when no trade error found

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -110,7 +110,7 @@ export const bestPriceDiscovery: Discovery = async (
     for (const result of rejectedResults) {
       await errorHandler(
         (result as PromiseRejectedResult).reason ||
-          'an unknwon error occurs when trying to fetch price'
+          'an unknown error occurs when trying to fetch price'
       );
     }
   }
@@ -124,6 +124,10 @@ export const bestPriceDiscovery: Discovery = async (
           order: TradeOrder;
         }>).value
     );
+
+  if (pricesWithClients.length === 0) {
+    throw new Error('No valid trade order has been found');
+  }
 
   const sorted = pricesWithClients.sort((p0, p1) => p1.amount - p0.amount);
 

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -126,7 +126,7 @@ export const bestPriceDiscovery: Discovery = async (
     );
 
   if (pricesWithClients.length === 0) {
-    throw new Error('No valid trade order has been found');
+    throw new Error('Not enough liquidity across providers for the requested amount');
   }
 
   const sorted = pricesWithClients.sort((p0, p1) => p1.amount - p0.amount);


### PR DESCRIPTION
Throw error when no trade error found.
We can't use the error handler in that case since the code would throw anyway with `Cannot read properties of undefined (reading 'amount')` at `  const bestAmount = sorted[0].amount`