### PR TITLE
Build proto in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "test:debug": "tsdx test --no-cache --runInBand",
     "lint": "tsdx lint src test --ignore-pattern src/api-spec/*",
     "lint:fix": "tsdx lint src test --fix --ignore-pattern src/api-spec/*",
-    "prepare": "tsdx build",
-    "postinstall": "yarn build:proto"
+    "prepare": "tsdx build && yarn build:proto"
   },
   "peerDependencies": {},
   "jest": {


### PR DESCRIPTION
It closes #141 

Use `prepare` instead of `prepublish` since it is deprecated. https://docs.npmjs.com/cli/v8/using-npm/scripts

Please review @tiero 