### PR TITLE
Add methods to buy and sell without broadcasting the tx

### DIFF
--- a/src/tradeCore.ts
+++ b/src/tradeCore.ts
@@ -117,7 +117,12 @@ export class TradeCore extends Core implements TradeInterface {
    * sending his own quoteAsset using the current market price wihtout
    * broadcasting the tx
    */
-  async buyWithoutComplete({ market, amount, asset, identity }: BuySellOpts): Promise<string> {
+  async buyWithoutComplete({
+    market,
+    amount,
+    asset,
+    identity,
+  }: BuySellOpts): Promise<string> {
     const swapAccept = await this.marketOrderRequest(
       market,
       TradeType.BUY,
@@ -126,7 +131,11 @@ export class TradeCore extends Core implements TradeInterface {
       identity
     );
     const autoComplete = true;
-    const txid = await this.marketOrderComplete(swapAccept, identity, autoComplete);
+    const txid = await this.marketOrderComplete(
+      swapAccept,
+      identity,
+      autoComplete
+    );
     return txid;
   }
 
@@ -170,7 +179,11 @@ export class TradeCore extends Core implements TradeInterface {
       identity
     );
     const autoComplete = true;
-    const txid = await this.marketOrderComplete(swapAccept, identity, autoComplete);
+    const txid = await this.marketOrderComplete(
+      swapAccept,
+      identity,
+      autoComplete
+    );
     return txid;
   }
 
@@ -297,11 +310,11 @@ export class TradeCore extends Core implements TradeInterface {
     const swapAcceptMessage = SwapAccept.fromBinary(swapAcceptSerialized);
     const transaction = swapAcceptMessage.transaction;
     const signedHex = await identity.signPset(transaction);
-    
+
     if (autoComplete) {
-      return signedHex
+      return signedHex;
     }
-    
+
     // Trader  adds his signed inputs to the transaction
     const swap = new Swap();
     const swapCompleteSerialized = swap.complete({

--- a/src/tradeCore.ts
+++ b/src/tradeCore.ts
@@ -10,7 +10,7 @@ import {
 import TraderClientInterface from './grpcClientInterface';
 import { SwapAccept } from './api-spec/protobuf/gen/js/tdex/v1/swap_pb';
 import { SwapTransaction } from './transaction';
-import { isPsetV0, isRawTransaction } from 'utils';
+import { isPsetV0, isRawTransaction } from './utils';
 
 export interface TDEXProvider {
   name: string;

--- a/src/tradeCore.ts
+++ b/src/tradeCore.ts
@@ -113,6 +113,24 @@ export class TradeCore extends Core implements TradeInterface {
   }
 
   /**
+   * Trade.buyWihtoutComplete let the trader buy the baseAsset,
+   * sending his own quoteAsset using the current market price wihtout
+   * broadcasting the tx
+   */
+  async buyWithoutComplete({ market, amount, asset, identity }: BuySellOpts): Promise<string> {
+    const swapAccept = await this.marketOrderRequest(
+      market,
+      TradeType.BUY,
+      amount,
+      asset,
+      identity
+    );
+    const autoComplete = true;
+    const txid = await this.marketOrderComplete(swapAccept, identity, autoComplete);
+    return txid;
+  }
+
+  /**
    * Trade.sell let the trader sell the baseAsset,
    * receiving the quoteAsset using the current market price
    */
@@ -130,6 +148,29 @@ export class TradeCore extends Core implements TradeInterface {
       identity
     );
     const txid = await this.marketOrderComplete(swapAccept, identity);
+    return txid;
+  }
+
+  /**
+   * Trade.sellWithoutComplete let the trader sell the baseAsset,
+   * receiving the quoteAsset using the current market price without
+   * broadcasting the tx
+   */
+  async sellWithoutComplete({
+    market,
+    amount,
+    asset,
+    identity,
+  }: BuySellOpts): Promise<string> {
+    const swapAccept = await this.marketOrderRequest(
+      market,
+      TradeType.SELL,
+      amount,
+      asset,
+      identity
+    );
+    const autoComplete = true;
+    const txid = await this.marketOrderComplete(swapAccept, identity, autoComplete);
     return txid;
   }
 
@@ -248,13 +289,19 @@ export class TradeCore extends Core implements TradeInterface {
 
   private async marketOrderComplete(
     swapAcceptSerialized: Uint8Array,
-    identity: IdentityInterface
+    identity: IdentityInterface,
+    autoComplete?: boolean
   ): Promise<string> {
     // trader need to check the signed inputs by the provider
     // and add his own inputs if all is correct
     const swapAcceptMessage = SwapAccept.fromBinary(swapAcceptSerialized);
     const transaction = swapAcceptMessage.transaction;
     const signedHex = await identity.signPset(transaction);
+    
+    if (autoComplete) {
+      return signedHex
+    }
+    
     // Trader  adds his signed inputs to the transaction
     const swap = new Swap();
     const swapCompleteSerialized = swap.complete({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,3 +66,21 @@ export function rejectIfSwapFail(
 
   return false;
 }
+
+export function isRawTransaction(tx: string): boolean {
+  try {
+    Transaction.fromHex(tx);
+    return true;
+  } catch (ignore) {
+    return false;
+  }
+}
+
+export function isPsetV0(tx: string): boolean {
+  try {
+    Psbt.fromBase64(tx);
+    return true;
+  } catch (ignore) {
+    return false;
+  }
+}


### PR DESCRIPTION
This adds 2 new methods to `TradeCore` class `buyWithoutComplete` and `sellWithoutComplete` that return the final signed raw transaction in hex format instead of calling providers CompleteTrade rpc that also broadcasts it.

This is needed to enable chained swaps.

Closes #153.

Please @tiero review this.