### PR TITLE
Re-add `tsdx build` to prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:debug": "tsdx test --no-cache --runInBand",
     "lint": "tsdx lint src test --ignore-pattern src/api-spec/*",
     "lint:fix": "tsdx lint src test --fix --ignore-pattern src/api-spec/*",
-    "prepare": "yarn build:proto && yarn build:swagger"
+    "prepare": "tsdx build && yarn build:proto && yarn build:swagger"
   },
   "peerDependencies": {},
   "jest": {


### PR DESCRIPTION
Fix installing sdk on browser app (tdex app) where module is missing dist-web folder. 